### PR TITLE
Us1834 large ebs volumes

### DIFF
--- a/lib/fog/aws/requests/compute/create_volume.rb
+++ b/lib/fog/aws/requests/compute/create_volume.rb
@@ -12,7 +12,7 @@ module Fog
         # * options<~Hash>
         #   * 'SnapshotId'<~String> - Optional, snapshot to create volume from
         #   * 'VolumeType'<~String> - Optional, volume type. standard or io1, default is standard.
-        #   * 'Iops'<~Integer> - Number of IOPS the volume supports. Required if VolumeType is io1, must be between 1 and 4000.
+        #   * 'Iops'<~Integer> - Number of IOPS the volume supports. Required if VolumeType is io1, must be between 1 and 20000.
         #   * 'Encrypted'<~Boolean> - Optional, specifies whether the volume should be encrypted, default is false.
         #
         # ==== Returns
@@ -82,8 +82,8 @@ module Fog
                 raise Fog::Compute::AWS::Error.new("VolumeIOPSLimit => Volume iops of #{iops} is too low; minimum is 100.")
               end
 
-              if iops > 4000
-                raise Fog::Compute::AWS::Error.new("VolumeIOPSLimit => Volume iops of #{iops} is too high; maximum is 4000.")
+              if iops > 20000
+                raise Fog::Compute::AWS::Error.new("VolumeIOPSLimit => Volume iops of #{iops} is too high; maximum is 20000.")
               end
             end
 

--- a/lib/fog/aws/version.rb
+++ b/lib/fog/aws/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module AWS
-    VERSION = "0.2.2.ey2"
+    VERSION = "0.2.2.ey3"
   end
 end

--- a/lib/fog/aws/version.rb
+++ b/lib/fog/aws/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module AWS
-    VERSION = "0.2.2.ey3"
+    VERSION = "0.2.2.ey4"
   end
 end

--- a/tests/requests/compute/volume_tests.rb
+++ b/tests/requests/compute/volume_tests.rb
@@ -195,8 +195,8 @@ Shindo.tests('Fog::Compute[:aws] | volume requests', ['aws']) do
     end
 
     # iops invalid value (greater than 4000)
-    tests("#create_volume('#{@server.availability_zone}', 1024, 'VolumeType' => 'io1', 'Iops' => 4001)").raises(Fog::Compute::AWS::Error) do
-      Fog::Compute[:aws].create_volume(@server.availability_zone, 1024, 'VolumeType' => 'io1', 'Iops' => 4001)
+    tests("#create_volume('#{@server.availability_zone}', 16384, 'VolumeType' => 'io1', 'Iops' => 20001)").raises(Fog::Compute::AWS::Error) do
+      Fog::Compute[:aws].create_volume(@server.availability_zone, 16384, 'VolumeType' => 'io1', 'Iops' => 20001)
     end
 
     @volume.destroy


### PR DESCRIPTION
Changes the IOPS limit from 4000 to 20000 to support the recent changes that allow for large EBS volumes (16384GB && 20000 IOPS are the new limits). Bumps the version #.
