### PR TITLE
[EYPP-9847] pass protocol to creation

### DIFF
--- a/lib/fog/aws/models/elbv2/target_group.rb
+++ b/lib/fog/aws/models/elbv2/target_group.rb
@@ -94,6 +94,7 @@ module Fog
         def save
           options = {
             :matcher => matcher,
+            :protocol => protocol,
             :healthy_threshold_count => healthy_threshold_count,
             :unhealthy_threshold_count => unhealthy_threshold_count,
             :health_check_interval_seconds => health_check_interval_seconds,

--- a/tests/models/elbv2/target_group_tests.rb
+++ b/tests/models/elbv2/target_group_tests.rb
@@ -18,6 +18,11 @@ Shindo.tests('AWS::elbv2 | target_group', ['aws', 'elbv2', 'models']) do
       @target_group.tg_attributes
     end
 
+    tests('https_protocol').returns('HTTPS') do
+      https_tg = ELBV2.target_groups.create(:name => "test-tg-2", :protocol => 'HTTPS')
+      https_tg.protocol
+    end
+
     tests('#register_targets') do
       @target_group.register_targets(@server1.id)
 


### PR DESCRIPTION
https://jira.devfactory.com/browse/EYPP-9847

*Confirmation video:* https://drive.google.com/file/d/1G1c0oa6guSnHZumISuW6FpcXJW5tsx3g/view?usp=sharing

*RC:* Fog-AWS ELBV2 save method wasn't passing protocol argument to the AWS creation request

*Fix summary:* Now the ELBV2 save method pass the protocol argument to the AWS creation request

*UTs:* added a test case.

*CI:* No CI for community project fork.