### PR TITLE
bugfix/EYPP-12292: Shared filesystem performance mode ignored

### DIFF
--- a/lib/fog/aws/requests/efs/create_file_system.rb
+++ b/lib/fog/aws/requests/efs/create_file_system.rb
@@ -16,7 +16,7 @@ module Fog
             :method           => 'POST',
             :expects          => 201,
             'CreationToken'   => creation_token,
-            'PerformanceMode' => options[:peformance_mode] || 'generalPurpose'
+            'PerformanceMode' => options[:performance_mode] || 'generalPurpose'
           })
         end
       end

--- a/lib/fog/aws/version.rb
+++ b/lib/fog/aws/version.rb
@@ -1,5 +1,5 @@
 module Fog
   module AWS
-    VERSION = "1.4.3"
+    VERSION = "1.4.4"
   end
 end


### PR DESCRIPTION
https://jira.devfactory.com/browse/EYPP-12292

---

**Fix Summary:** Fix performance_mode typo in `fog-aws`
**UT:** Tests provided in original project - this one not configured correctly.
**E2E:** https://jira.devfactory.com/browse/EYPP-14536 / Step 7 was failing before the Fix
**Confirmation Video:** https://drive.google.com/file/d/1tx8mCOImXVYk7NBlFQm8QyfyvmgdMSlV/view?usp=sharing
**CI/CD:** Not Configured for this project created https://jira.devfactory.com/browse/EYPP-14537